### PR TITLE
Update uri.js version to 1.15.2 to remove jQuery dep and useless main js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "angular"
   ],
   "dependencies": {
-    "uri.js": "1.14.1"
+    "uri.js": "1.15.2"
   },
   "main": [
     "angular-uri.js"


### PR DESCRIPTION
- [x] https://github.com/medialize/URI.js/issues/227
- [x] Create tag v0.1.1 on merge commit of this PR
